### PR TITLE
feat: add FastAPI web service and Render deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+
+# API for my Classicbook ETL pipeline project
+
+A FastAPI service that serves data from my Classic Book ETL pipeline, 
+providing TSV and JSON endpoints for easy integration.
+
+
+## How to run locally
+
+# Set your GitHub raw URL for imitation.tsv
+export DATA_URL="https://raw.githubusercontent.com/<your-username>/classicbook-datasets/main/data/imitation.tsv"
+
+# Start the API
+uvicorn app:app --reload

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ providing TSV and JSON endpoints for easy integration.
 ## How to run locally
 
 # Set your GitHub raw URL for imitation.tsv
-export DATA_URL="https://raw.githubusercontent.com/<your-username>/classicbook-datasets/main/data/imitation.tsv"
+export DATA_URL="https://github.com/bravojuandb/classicbook-datasets/tree/main/data/aligned/book1_aligned.tsv"
 
 # Start the API
 uvicorn app:app --reload

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import os
+import csv
+import requests
+from fastapi import FastAPI, Response, HTTPException
+
+app = FastAPI()
+
+DATA_URL = os.getenv("DATA_URL")
+if not DATA_URL:
+    raise RuntimeError("DATA_URL environment variable not set.")
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.get("/export/tsv")
+def export_tsv():
+    try:
+        r = requests.get(DATA_URL, timeout=10)
+        r.raise_for_status()
+        return Response(content=r.text, media_type="text/tab-separated-values; charset=utf-8")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/export/json")
+def export_json():
+    try:
+        r = requests.get(DATA_URL, timeout=10)
+        r.raise_for_status()
+        rows = list(csv.DictReader(r.text.splitlines(), delimiter="\t"))
+        return rows
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/render.yml
+++ b/render.yml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: classicbook-api
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: DATA_URL
+        value: https://raw.githubusercontent.com/bravojuandb/classicbook-datasets/main/data/aligned/book1_aligned.tsv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+
+# Python framework for building APIs quickly
+fastapi
+
+# Lightweight web server for running FastAPI
+uvicorn
+
+# Python library for making HTTP requests
+requests


### PR DESCRIPTION
This PR introduces a FastAPI-based web service to serve data for the Classic Book ETL pipeline.

Changes include:
- Implemented a basic FastAPI application with initial endpoints.
- Added `render.yml` configuration for deployment on Render.
- Configured environment variable `DATA_URL` to point to the aligned dataset.

This setup enables the ETL pipeline to fetch its source data from a hosted API.